### PR TITLE
Update task yamls

### DIFF
--- a/lm_eval/tasks/basque_bench/basque_bench.yaml
+++ b/lm_eval/tasks/basque_bench/basque_bench.yaml
@@ -1,4 +1,4 @@
-group: basque_bench
+tag: basque_bench
 task:
     - belebele_eus_Latn
     - xstorycloze_eu

--- a/lm_eval/tasks/catalan_bench/catalan_bench.yaml
+++ b/lm_eval/tasks/catalan_bench/catalan_bench.yaml
@@ -1,4 +1,4 @@
-group: catalan_bench
+tag: catalan_bench
 task:
     - belebele_cat_Latn
     - xnli_ca

--- a/lm_eval/tasks/galician_bench/flores_gl/_flores_common_yaml
+++ b/lm_eval/tasks/galician_bench/flores_gl/_flores_common_yaml
@@ -1,4 +1,4 @@
-group: flores
+tag: flores
 dataset_path: facebook/flores
 dataset_name: all
 output_type: generate_until

--- a/lm_eval/tasks/portuguese_bench/flores_pt/_flores_common_yaml
+++ b/lm_eval/tasks/portuguese_bench/flores_pt/_flores_common_yaml
@@ -1,4 +1,4 @@
-group: flores
+tag: flores
 dataset_path: facebook/flores
 dataset_name: all
 output_type: generate_until

--- a/lm_eval/tasks/portuguese_bench/portuguese_bench.yaml
+++ b/lm_eval/tasks/portuguese_bench/portuguese_bench.yaml
@@ -1,4 +1,4 @@
-group: portuguese_bench
+tag: portuguese_bench
 task:
   - belebele_por_Latn
   - flores_pt

--- a/lm_eval/tasks/spanish_bench/flores_es/_flores_common_yaml
+++ b/lm_eval/tasks/spanish_bench/flores_es/_flores_common_yaml
@@ -1,4 +1,4 @@
-group: flores
+tag: flores
 dataset_path: facebook/flores
 dataset_name: all
 output_type: generate_until

--- a/lm_eval/tasks/spanish_bench/spanish_bench.yaml
+++ b/lm_eval/tasks/spanish_bench/spanish_bench.yaml
@@ -1,4 +1,4 @@
-group: spanish_bench
+tag: spanish_bench
 task:
   - belebele_spa_Latn
   - wnli_es


### PR DESCRIPTION
This PR updates the task YAMLs for `basque_bench`, `catalan_bench`, `galician_bench`, `portuguese_bench`, and `spanish_bench` to use the `tag` keyword instead of the `group` keyword when referring to a set of tasks, in order to comply with the changes to the `lm-evaluation-harness` API as of version 0.4.4: https://github.com/EleutherAI/lm-evaluation-harness/releases/tag/v0.4.4.