### PR TITLE
Update additional flores tasks YAMLs to comply with harness v.0.4.4+

### DIFF
--- a/lm_eval/tasks/basque_bench/flores_eu/flores_eu.yaml
+++ b/lm_eval/tasks/basque_bench/flores_eu/flores_eu.yaml
@@ -1,4 +1,4 @@
-group: flores_eu
+tag: flores_eu
 task:
   - flores_es-eu
   - flores_eu-es

--- a/lm_eval/tasks/catalan_bench/flores_ca/flores_ca.yaml
+++ b/lm_eval/tasks/catalan_bench/flores_ca/flores_ca.yaml
@@ -1,4 +1,4 @@
-group: flores_ca
+tag: flores_ca
 task:
   - flores_es-ca
   - flores_ca-es

--- a/lm_eval/tasks/galician_bench/flores_gl/flores_gl.yaml
+++ b/lm_eval/tasks/galician_bench/flores_gl/flores_gl.yaml
@@ -1,4 +1,4 @@
-group: flores_gl
+tag: flores_gl
 task:
   - flores_es-gl
   - flores_gl-es

--- a/lm_eval/tasks/portuguese_bench/flores_pt/flores_pt.yaml
+++ b/lm_eval/tasks/portuguese_bench/flores_pt/flores_pt.yaml
@@ -1,4 +1,4 @@
-group: flores_pt
+tag: flores_pt
 task:
   - flores_es-pt
   - flores_pt-es

--- a/lm_eval/tasks/spanish_bench/flores_es/flores_es.yaml
+++ b/lm_eval/tasks/spanish_bench/flores_es/flores_es.yaml
@@ -1,4 +1,4 @@
-group: flores_es
+tag: flores_es
 task:
   - flores_es-en
   - flores_en-es


### PR DESCRIPTION
This PR changes the `group` key to `tag` for some additional `flores` YAMLs that had been overlooked in https://github.com/langtech-bsc/mlops-lm-evaluation-harness/pull/5.