### PR TITLE
fix bug: change config[group] to tag and group

### DIFF
--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -489,7 +489,8 @@ class TaskManager:
                         )
                     elif self._config_is_group(config):
                         # This is a group config
-                        tasks_and_groups[config["group"]] = {
+                        tag_group = config["group"] if "group" in config else config["tag"]
+                        tasks_and_groups[tag_group] = {
                             "type": "group",
                             "task": -1,  # This signals that
                             # we don't need to know


### PR DESCRIPTION
The official repository has updated certain datasets by changing the key from group to tag. However, this update was applied inconsistently, resulting in some datasets using tag while others still use group. This inconsistency is causing issues during task evaluation, as the code isn't handling both cases properly.

To work around this, the easiest solution I've found is to dynamically retrieve either group or tag from the configuration, depending on which one is present.
Before:
```
tasks_and_groups[tag_group]
```
After:
```
tag_group = config["group"] if "group" in config else config["tag"]
tasks_and_groups[tag_group]
```