### PR TITLE
Change all group YAMLs to use 'group' keyword

### DIFF
--- a/lm_eval/tasks/basque_bench/basque_bench.yaml
+++ b/lm_eval/tasks/basque_bench/basque_bench.yaml
@@ -1,4 +1,4 @@
-tag: basque_bench
+group: basque_bench
 task:
     - belebele_eus_Latn
     - xstorycloze_eu

--- a/lm_eval/tasks/basque_bench/flores_eu/flores_eu.yaml
+++ b/lm_eval/tasks/basque_bench/flores_eu/flores_eu.yaml
@@ -1,4 +1,4 @@
-tag: flores_eu
+group: flores_eu
 task:
   - flores_es-eu
   - flores_eu-es

--- a/lm_eval/tasks/catalan_bench/catalan_bench.yaml
+++ b/lm_eval/tasks/catalan_bench/catalan_bench.yaml
@@ -1,4 +1,4 @@
-tag: catalan_bench
+group: catalan_bench
 task:
     - belebele_cat_Latn
     - xnli_ca

--- a/lm_eval/tasks/catalan_bench/flores_ca/flores_ca.yaml
+++ b/lm_eval/tasks/catalan_bench/flores_ca/flores_ca.yaml
@@ -1,4 +1,4 @@
-tag: flores_ca
+group: flores_ca
 task:
   - flores_es-ca
   - flores_ca-es

--- a/lm_eval/tasks/galician_bench/flores_gl/flores_gl.yaml
+++ b/lm_eval/tasks/galician_bench/flores_gl/flores_gl.yaml
@@ -1,4 +1,4 @@
-tag: flores_gl
+group: flores_gl
 task:
   - flores_es-gl
   - flores_gl-es

--- a/lm_eval/tasks/galician_bench/galician_bench.yaml
+++ b/lm_eval/tasks/galician_bench/galician_bench.yaml
@@ -1,4 +1,4 @@
-tag: galician_bench
+group: galician_bench
 task:
   - belebele_glg_Latn
   - flores_gl

--- a/lm_eval/tasks/portuguese_bench/flores_pt/flores_pt.yaml
+++ b/lm_eval/tasks/portuguese_bench/flores_pt/flores_pt.yaml
@@ -1,4 +1,4 @@
-tag: flores_pt
+group: flores_pt
 task:
   - flores_es-pt
   - flores_pt-es

--- a/lm_eval/tasks/portuguese_bench/portuguese_bench.yaml
+++ b/lm_eval/tasks/portuguese_bench/portuguese_bench.yaml
@@ -1,4 +1,4 @@
-tag: portuguese_bench
+group: portuguese_bench
 task:
   - belebele_por_Latn
   - flores_pt

--- a/lm_eval/tasks/spanish_bench/flores_es/flores_es.yaml
+++ b/lm_eval/tasks/spanish_bench/flores_es/flores_es.yaml
@@ -1,4 +1,4 @@
-tag: flores_es
+group: flores_es
 task:
   - flores_es-en
   - flores_en-es

--- a/lm_eval/tasks/spanish_bench/spanish_bench.yaml
+++ b/lm_eval/tasks/spanish_bench/spanish_bench.yaml
@@ -1,4 +1,4 @@
-tag: spanish_bench
+group: spanish_bench
 task:
   - belebele_spa_Latn
   - copa_es


### PR DESCRIPTION
This PR is an undoing of the changes that were made in https://github.com/langtech-bsc/mlops-lm-evaluation-harness/pull/5 and https://github.com/langtech-bsc/mlops-lm-evaluation-harness/pull/6, where the `group` keyword of the group YAMLs was changed to `tag`. This change appears to have caused the Harness `lm_eval` code to break with the following error:
```
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/gpfs/projects/bsc88/mlops-lm-evaluation-harness/production/lm_eval/__main__.py", line 486, in <module>
    cli_evaluate()
  File "/gpfs/projects/bsc88/mlops-lm-evaluation-harness/production/lm_eval/__main__.py", line 395, in cli_evaluate
    results = evaluator.simple_evaluate(
  File "/gpfs/projects/bsc88/mlops-lm-evaluation-harness/production/lm_eval/utils.py", line 397, in _wrapper
    return fn(*args, **kwargs)
  File "/gpfs/projects/bsc88/mlops-lm-evaluation-harness/production/lm_eval/evaluator.py", line 301, in simple_evaluate
    results = evaluate(
  File "/gpfs/projects/bsc88/mlops-lm-evaluation-harness/production/lm_eval/utils.py", line 397, in _wrapper
    return fn(*args, **kwargs)
  File "/gpfs/projects/bsc88/mlops-lm-evaluation-harness/production/lm_eval/evaluator.py", line 611, in evaluate
    results, versions, show_group_table, *_ = consolidate_group_results(
  File "/gpfs/projects/bsc88/mlops-lm-evaluation-harness/production/lm_eval/evaluator_utils.py", line 439, in consolidate_group_results
    task_list = _task_aggregation_list[group_or_task]
KeyError: None
```
Based on the debugging that I did, this error seems to arise due to the `ConfigurationGroup` object inside of the task dictionary not being properly set because it is looking for a `'group'` keyword in the config and does not recognize `'tag'`. 

This change also restores all of the `{lang}_bench` YAMLS (and their corresponding `flores` subtask YAMLs) back to how they are in `lm-evaluation-harness` (e.g. https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/tasks/basque_bench/basque_bench.yaml). 