### PR TITLE
Map Parafraseja labels to numerical targets

### DIFF
--- a/lm_eval/tasks/catalan_bench/parafraseja.yaml
+++ b/lm_eval/tasks/catalan_bench/parafraseja.yaml
@@ -8,7 +8,7 @@ validation_split: validation
 doc_to_choice: '{{[sentence1+", veritat? No, "+sentence2, sentence1+", veritat? Sí, "+sentence2]}}'
 process_docs: !function utils.process_docs_paraphrases
 doc_to_text: ''
-doc_to_target: label
+doc_to_target: !function utils.map_label_to_index
 metric_list:
   - metric: acc
     aggregation: mean

--- a/lm_eval/tasks/catalan_bench/utils.py
+++ b/lm_eval/tasks/catalan_bench/utils.py
@@ -140,3 +140,11 @@ def rouge1_agg(items):
     preds = list(zip(*items))[1]
     rouge_scorer = evaluate.load("rouge")
     return rouge_scorer.compute(predictions=preds, references=refs)["rouge1"]
+
+def map_label_to_index(doc):
+    if doc["label"] == "No Parafrasis":
+        return 0
+    elif doc["label"] == "Parafrasis":
+        return 1
+    else:
+        raise ValueError(f"Unexpected label: {doc['label']}")


### PR DESCRIPTION
## Pull Request Checklist
- [x] The title of the PR is clear and concise.
- [x] I have provided a detailed description of the changes and the reason for the changes.
- [x] I have linked the related issue(s) in the description (if applicable).
- [x] I have followed the coding guidelines of this project.
- [x] I have ensured there are no breaking changes.
- [x] I have updated related documentation (if applicable).
- [x] I have added reviewers, including at least one member of the MLOps team (@hrosegalb, @PaulNdrei, @ankush13r, @igorktech)

## Description
This PR fixes the following error with the Parafraseja task:
```
2024-11-21:09:24:12,518 WARNING  [task.py:1456] Label index was not in within range of available choices,Sample:
{'id': 'sts_7493_2', 'source': 'sts', 'label': 'No Parafrasis', 'sentence1': 'Els seus antecedents policials sumen gairebé una quarantena', 'sentence2': 'té una desena de condecoracions policials.'}
```
We found that this error was caused by the lack of a mapping between the string labels of the dataset and the sequential targets required by Harness. See issue discussions for more details.

## Issue Link(s)
Closes #19

## Testing
I manually ran an evaluation of the gemma-2-2b model with the launch script and selected only the Parafraseja task and the logs show the evaluation results, unlike before, where the result was always 0 due to this error.