### PR TITLE
Fix code to write results out in desirable format

### DIFF
--- a/lm_eval/loggers/evaluation_tracker.py
+++ b/lm_eval/loggers/evaluation_tracker.py
@@ -226,11 +226,10 @@ class EvaluationTracker:
                 )
 
                 path = Path(self.output_path if self.output_path else Path.cwd())
-                path = path.joinpath(self.general_config_tracker.model_name_sanitized)
-                path.mkdir(parents=True, exist_ok=True)
+                directory_path = path.parent
+                os.makedirs(directory_path, exist_ok=True)
 
-                self.date_id = datetime.now().isoformat().replace(":", "-")
-                file_results_aggregated = path.joinpath(f"results_{self.date_id}.json")
+                file_results_aggregated = path
                 file_results_aggregated.open("w", encoding="utf-8").write(dumped)
 
                 if self.api and self.push_results_to_hub:
@@ -286,11 +285,12 @@ class EvaluationTracker:
             try:
                 eval_logger.info(f"Saving per-sample results for: {task_name}")
 
-                path = Path(self.output_path if self.output_path else Path.cwd())
-                path = path.joinpath(self.general_config_tracker.model_name_sanitized)
+                directory_path = os.path.dirname(self.output_path) if self.output_path else os.path.dirname(Path.cwd())
+                path = Path(directory_path if self.output_path else Path.cwd())
                 path.mkdir(parents=True, exist_ok=True)
-
-                file_results_samples = path.joinpath(
+                
+                self.date_id = datetime.now().isoformat().replace(":", "-")
+                file_results_samples = directory_path.joinpath(
                     f"samples_{task_name}_{self.date_id}.jsonl"
                 )
 


### PR DESCRIPTION
## Description

This pull request fixes an issue with `mlops-lm-evaluation-harness` to write results and samples out in the desired format. The default behavior of EleutherAI's `lm-evalution-harness` code is to write results out using the following format:
`<results_dir>/__sanitized__model__name/results_{datetime}.json`, e.g. `<results_dir>/__gpfs__projects__bsc88__hf-models__Meta-Llama-3-8B/results_2024-11-22T15-21-20.898615.json`. If the `--log_samples` flag was used when running evaluations, then JSONL files containing samples would also be stored under the `__sanitized__model_name/` directory with a similar file name format: `samples_{task_name}_{datetime}.jsonl`, e.g. `<results_dir>/__gpfs__projects__bsc88__hf-models__Meta-Llama-3-8B/samples_copa_es_2024-11-28T11-31-16.865765.jsonl`. 

At some point, Irene Baucells changed the code on the fork of `lm-evaluation-harness` that she was using to run evaluations in order to write results out in the format that she preferred. This change allowed her to pass the entire file path of the results file when using the `--output_path` flag, e.g. `results/Meta-Llama-3-8B/5-shot/results:Meta-Llama-3-8B:xquad_es:5-shot_12336506.json`. When we created this new fork of `harness`, we were not aware that she had changed the code in order to do this, so we were getting strange file paths for results, e.g. `results/Meta-Llama-3-8B/5-shot/results:Meta-Llama-3-8B:xstorycloze_gl:5-shot_12121493.json/__gpfs__projects__bsc88__hf-models__Meta-Llama-3-8B/results_2024-11-22T15-21-20.898615.json`. This is because `results/Meta-Llama-3-8B/5-shot/results:Meta-Llama-3-8B:xstorycloze_gl:5-shot_12121493.json` was being interpreted as a directory by the `harness` code. I have modified the code so that it writes the files out in the format that BSC researchers have come to expect.

## Pull Request Checklist
- [X] The title of the PR is clear and concise.
- [X] I have provided a detailed description of the changes and the reason for the changes.
- [X] I have linked the related issue(s) in the description (if applicable).
- [X] I have followed the coding guidelines of this project.
- [X] I have ensured there are no breaking changes.
- [ ] I have updated related documentation (if applicable).
- [ ] I have added reviewers, including at least one member of the MLOps team (@hrosegalb, @PaulNdrei, @ankush13r, @igorktech)

## New Task Checklist
- [ ] I have ensured that the dataset used in the task has been human annotated or translated, or that, if synthetic, a strong and reliable human revision has taken place.
- [ ]  I have explored existing Harness tasks to check the types of prompts, metrics and setups used in similar tasks, and either adopted the same for my task or have a strong reason(s) not to do it (please provide justification in description).
- [ ]  I have reviewed the dataset structure and contents to ensure that the prompt used does not impact the quality of the input given to the models.
- [ ]  If errors were detected, I have added suitable pre- or post-processing to the task.
- [ ]  I have tested that my task runs from beginning to end.
- [ ]  I have reviewed the inputs given to the models to ensure that instructions are natural, grammatical, and as I expected overall (e.g., punctuation and capitalization are used correctly, the few-shot context is not truncated, etc.).
- [ ]  I have reviewed the outputs of the evaluations of the models, making sure that metrics and other aspects of the setup work as I expected.
- [ ]  If my task is in Spanish, Catalan, Galician, Basque, Portuguese or English, I have talked to Javier Aula-Blasco regarding the possibility of adding it to one of the Benches.

