### PR TITLE
add cognitive bias evaluation tasks

### DIFF
--- a/lm_eval/tasks/cognitive_bias/_cobie_arc_3choices.yaml
+++ b/lm_eval/tasks/cognitive_bias/_cobie_arc_3choices.yaml
@@ -1,0 +1,15 @@
+dataset_path: /gpfs/projects/bsc88/text/bias/cobie/modified_datasets/ARC_3opt/cobie_arc_3choices.py
+output_type: multiple_choice
+training_split: null
+validation_split: null
+test_split: train
+doc_to_text: "Question: {{question}}\nPossible answers: {{choices.text[0]}}, {{choices.text[1]}}, {{choices.text[2]}}.\nAnswer:"
+doc_to_target: "{{choices.label.index(answerKey)}}"
+doc_to_choice: "{{choices.text}}"
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true

--- a/lm_eval/tasks/cognitive_bias/_cobie_arc_4choices.yaml
+++ b/lm_eval/tasks/cognitive_bias/_cobie_arc_4choices.yaml
@@ -1,0 +1,15 @@
+dataset_path: /gpfs/projects/bsc88/text/bias/cobie/modified_datasets/ARC/cobie_arc_4choices.py
+output_type: multiple_choice
+training_split: null
+validation_split: null
+test_split: train
+doc_to_text: "Question: {{question}}\nPossible answers: {{choices.text[0]}}, {{choices.text[1]}}, {{choices.text[2]}}, {{choices.text[3]}}.\nAnswer:"
+doc_to_target: "{{choices.label.index(answerKey)}}"
+doc_to_choice: "{{choices.text}}"
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true

--- a/lm_eval/tasks/cognitive_bias/cobie_arc_challenge_3choices.yaml
+++ b/lm_eval/tasks/cognitive_bias/cobie_arc_challenge_3choices.yaml
@@ -1,0 +1,3 @@
+include: _cobie_arc_3choices.yaml
+task: cobie_arc_challenge_3choices
+dataset_name: cobie_arc_challenge_3choices

--- a/lm_eval/tasks/cognitive_bias/cobie_arc_challenge_4choices.yaml
+++ b/lm_eval/tasks/cognitive_bias/cobie_arc_challenge_4choices.yaml
@@ -1,0 +1,3 @@
+include: _cobie_arc_4choices.yaml
+task: cobie_arc_challenge_4choices
+dataset_name: cobie_arc_challenge_4choices

--- a/lm_eval/tasks/cognitive_bias/cobie_arc_easy_3choices.yaml
+++ b/lm_eval/tasks/cognitive_bias/cobie_arc_easy_3choices.yaml
@@ -1,0 +1,3 @@
+include: _cobie_arc_3choices.yaml
+task: cobie_arc_easy_3choices
+dataset_name: cobie_arc_easy_3choices

--- a/lm_eval/tasks/cognitive_bias/cobie_arc_easy_4choices.yaml
+++ b/lm_eval/tasks/cognitive_bias/cobie_arc_easy_4choices.yaml
@@ -1,0 +1,3 @@
+include: _cobie_arc_4choices.yaml
+task: cobie_arc_easy_4choices
+dataset_name: cobie_arc_easy_4choices

--- a/lm_eval/tasks/cognitive_bias/cobie_sst2.yaml
+++ b/lm_eval/tasks/cognitive_bias/cobie_sst2.yaml
@@ -1,0 +1,12 @@
+task: cobie_sst2
+dataset_path: /gpfs/projects/bsc88/text/bias/cobie/modified_datasets/sst2/cobie_sst2.py
+dataset_name: cobie_sst2
+output_type: multiple_choice
+training_split: null
+validation_split: null
+test_split: train
+doc_to_text: "{{few_shot_string}}Review: {{sentence}}\nSentiment:"
+doc_to_target: label
+doc_to_choice: ["negative", "positive"]
+metric_list:
+  - metric: acc

--- a/lm_eval/tasks/cognitive_bias/cobie_sst2_hard.yaml
+++ b/lm_eval/tasks/cognitive_bias/cobie_sst2_hard.yaml
@@ -1,0 +1,12 @@
+task: cobie_sst2_hard
+dataset_path: /gpfs/projects/bsc88/text/bias/cobie/modified_datasets/sst2/cobie_sst2.py
+dataset_name: cobie_sst2_hard
+output_type: multiple_choice
+training_split: null
+validation_split: null
+test_split: train
+doc_to_text: "{{few_shot_hard_string}}Review: {{sentence}}\nSentiment:"
+doc_to_target: label
+doc_to_choice: ["negative", "positive", "neutral"]
+metric_list:
+  - metric: acc

--- a/lm_eval/tasks/cognitive_bias/cognitive_bias.yaml
+++ b/lm_eval/tasks/cognitive_bias/cognitive_bias.yaml
@@ -1,0 +1,8 @@
+group: cognitive_bias
+task:
+  - cobie_sst2
+  - cobie_sst2_hard
+  - cobie_arc_easy_3choices
+  - cobie_arc_challenge_3choices
+  - cobie_arc_easy_4choices
+  - cobie_arc_challenge_4choices


### PR DESCRIPTION
## Description
I have added the tasks to evaluate cognitive biases. I have grouped them in several subtask within the task/bench named "cognitive_bias". All of them have the prefix "cobie" to make them distinguishable from the original datasets (in fact, the original arc is also in harness).

Note that the datasets are already on HF, but in private. I will make them public once the paper is released next January. For now, I have pointed to the corresponding dataloaders in gpfs, but I will change it once the datasets are publicly available.

## Issue Link(s)
#15 

## Testing
I have tested that the tasks work with the singularity image for galtea, as Hannah showed me. Let me know if you need more details.

