### PR TITLE
Fix formatting issues in XNLI and TECA

### DIFF
--- a/lm_eval/tasks/catalan_bench/utils.py
+++ b/lm_eval/tasks/catalan_bench/utils.py
@@ -10,29 +10,39 @@ from lm_eval.utils import general_detokenize
 def lowercase_first_letter(text):
     return text[0].lower() + text[1:]
 
+def uppercase_first_letter(text):
+    return text[0].upper() + text[1:]
 
 def process_doc_nli(dataset):
+
+    def filter_fn(doc):
+        # There shouldn't be any final punctuation marks (except periods) in the premise or the hypothesis.
+        # They're supposed to be one single sentence in order to be concatenated properly in the prompt.
+        if any([punct in sent for punct in ["!", "?", "¿"] for sent in [doc["premise"], doc["hypothesis"]]]):
+            return False
+
+        return True
+
     def process_fn(doc):
         # Detokenize(remove extra whitespaces)
         doc["premise"] = general_detokenize(doc["premise"]).strip()
         doc["hypothesis"] = general_detokenize(doc["hypothesis"]).strip()
-        # Remove last punctuation mark in the premise
-        doc["premise"] = (
-            doc["premise"][:-1]
-            if doc["premise"].endswith((".", ",", "!", "?"))
-            else doc["premise"]
-        )
+
+        # Remove periods from the end of the premise
+        doc["premise"] = doc["premise"].rstrip(".")
+
         # Lowercase the first letter in the hypothesis
         doc["hypothesis"] = lowercase_first_letter(doc["hypothesis"])
-        # Ensure that the hypothesis ends with a dot
-        doc["hypothesis"] = (
-            (doc["hypothesis"] + ".")
-            if not doc["hypothesis"].endswith(".")
-            else doc["hypothesis"]
-        )
+
+        # Uppercase the first letter in the premise
+        doc["premise"] = uppercase_first_letter(doc["premise"])
+
+        # Ensure that the hypothesis ends with a single period
+        doc["hypothesis"] = doc["hypothesis"].rstrip(".") + "."
+
         return doc
 
-    return dataset.map(process_fn)
+    return dataset.filter(filter_fn).map(process_fn)
 
 
 def process_results_coqcat(doc, results):

--- a/lm_eval/tasks/catalan_bench/utils.py
+++ b/lm_eval/tasks/catalan_bench/utils.py
@@ -18,7 +18,7 @@ def process_doc_nli(dataset):
     def filter_fn(doc):
         # There shouldn't be any final punctuation marks (except periods) in the premise or the hypothesis.
         # They're supposed to be one single sentence in order to be concatenated properly in the prompt.
-        if any([punct in sent for punct in ["!", "?", "¿"] for sent in [doc["premise"], doc["hypothesis"]]]):
+        if any([punct in sent for punct in ["¡", "!", "?", "¿", "..."] for sent in [doc["premise"], doc["hypothesis"]]]):
             return False
 
         return True

--- a/lm_eval/tasks/catalan_bench/utils.py
+++ b/lm_eval/tasks/catalan_bench/utils.py
@@ -18,7 +18,7 @@ def process_doc_nli(dataset):
     def filter_fn(doc):
         # There shouldn't be any final punctuation marks (except periods) in the premise or the hypothesis.
         # They're supposed to be one single sentence in order to be concatenated properly in the prompt.
-        if any([punct in sent for punct in ["¡", "!", "?", "¿", "..."] for sent in [doc["premise"], doc["hypothesis"]]]):
+        if any([punct in sent for punct in ["¡", "!", "?", "¿", "...", ":", ";"] for sent in [doc["premise"], doc["hypothesis"]]]):
             return False
 
         return True

--- a/lm_eval/tasks/galician_bench/utils.py
+++ b/lm_eval/tasks/galician_bench/utils.py
@@ -147,7 +147,7 @@ def process_doc_nli(dataset):
     def filter_fn(doc):
         # There shouldn't be any final punctuation marks (except periods) in sentence1 or sentence2.
         # They're supposed to be one single sentence in order to be concatenated properly in the prompt.
-        if any([punct in sent for punct in ["¡", "!", "?", "¿", "..."] for sent in [doc["sentence1"], doc["sentence2"]]]):
+        if any([punct in sent for punct in ["¡", "!", "?", "¿", "...", ":", ";"] for sent in [doc["sentence1"], doc["sentence2"]]]):
             return False
 
         return True

--- a/lm_eval/tasks/iberobench_english/iberobench_english.yaml
+++ b/lm_eval/tasks/iberobench_english/iberobench_english.yaml
@@ -1,0 +1,5 @@
+group: iberobench_english
+task:
+  - xnli_en_iberobench
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/iberobench_english/utils.py
+++ b/lm_eval/tasks/iberobench_english/utils.py
@@ -1,0 +1,39 @@
+from lm_eval.utils import general_detokenize
+
+
+def lowercase_first_letter(text):
+    return text[0].lower() + text[1:]
+
+def uppercase_first_letter(text):
+    return text[0].upper() + text[1:]
+
+def process_doc_nli(dataset):
+
+    def filter_fn(doc):
+        # There shouldn't be any final punctuation marks (except periods) in the premise or the hypothesis.
+        # They're supposed to be one single sentence in order to be concatenated properly in the prompt.
+        if any([punct in sent for punct in ["¡", "!", "?", "¿", "...", ":", ";"] for sent in [doc["premise"], doc["hypothesis"]]]):
+            return False
+
+        return True
+
+    def process_fn(doc):
+        # Detokenize(remove extra whitespaces)
+        doc["premise"] = general_detokenize(doc["premise"]).strip()
+        doc["hypothesis"] = general_detokenize(doc["hypothesis"]).strip()
+
+        # Remove periods from the end of the premise
+        doc["premise"] = doc["premise"].rstrip(".")
+
+        # Lowercase the first letter in the hypothesis
+        doc["hypothesis"] = lowercase_first_letter(doc["hypothesis"])
+
+        # Uppercase the first letter in the premise
+        doc["premise"] = uppercase_first_letter(doc["premise"])
+
+        # Ensure that the hypothesis ends with a single period
+        doc["hypothesis"] = doc["hypothesis"].rstrip(".") + "."
+
+        return doc
+
+    return dataset.filter(filter_fn).map(process_fn)

--- a/lm_eval/tasks/iberobench_english/xnli_en_iberobench.yaml
+++ b/lm_eval/tasks/iberobench_english/xnli_en_iberobench.yaml
@@ -1,0 +1,20 @@
+# Task configuration derived from Eleuther AI's implementation as of March 18, 2025, supplemented with an additional preprocessing function.
+
+task: xnli_en_iberobench
+dataset_path: xnli
+dataset_name: en
+output_type: multiple_choice
+training_split: train
+validation_split: validation
+doc_to_text: ''
+target_delimiter: ''
+process_docs: !function utils.process_doc_nli
+doc_to_target: label
+doc_to_choice: '{{[premise+", right? Yes, "+hypothesis,premise+", right? Also, "+hypothesis,premise+",
+  right? No, "+hypothesis]}}'
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/spanish_bench/utils.py
+++ b/lm_eval/tasks/spanish_bench/utils.py
@@ -10,29 +10,39 @@ from lm_eval.utils import general_detokenize
 def lowercase_first_letter(text):
     return text[0].lower() + text[1:]
 
+def uppercase_first_letter(text):
+    return text[0].upper() + text[1:]
 
 def process_doc_nli(dataset):
+
+    def filter_fn(doc):
+        # There shouldn't be any final punctuation marks (except periods) in the premise or the hypothesis.
+        # They're supposed to be one single sentence in order to be concatenated properly in the prompt.
+        if any([punct in sent for punct in ["¡", "!", "?", "¿", "..."] for sent in [doc["premise"], doc["hypothesis"]]]):
+            return False
+
+        return True
+
     def process_fn(doc):
         # Detokenize(remove extra whitespaces)
         doc["premise"] = general_detokenize(doc["premise"]).strip()
         doc["hypothesis"] = general_detokenize(doc["hypothesis"]).strip()
-        # Remove last punctuation mark in the premise
-        doc["premise"] = (
-            doc["premise"][:-1]
-            if doc["premise"].endswith((".", ",", "!", "?"))
-            else doc["premise"]
-        )
+
+        # Remove periods from the end of the premise
+        doc["premise"] = doc["premise"].rstrip(".")
+
         # Lowercase the first letter in the hypothesis
         doc["hypothesis"] = lowercase_first_letter(doc["hypothesis"])
-        # Ensure that the hypothesis ends with a dot
-        doc["hypothesis"] = (
-            (doc["hypothesis"] + ".")
-            if not doc["hypothesis"].endswith(".")
-            else doc["hypothesis"]
-        )
+
+        # Uppercase the first letter in the premise
+        doc["premise"] = uppercase_first_letter(doc["premise"])
+
+        # Ensure that the hypothesis ends with a single period
+        doc["hypothesis"] = doc["hypothesis"].rstrip(".") + "."
+
         return doc
 
-    return dataset.map(process_fn)
+    return dataset.filter(filter_fn).map(process_fn)
 
 
 def process_xlsum(dataset):

--- a/lm_eval/tasks/spanish_bench/utils.py
+++ b/lm_eval/tasks/spanish_bench/utils.py
@@ -18,7 +18,7 @@ def process_doc_nli(dataset):
     def filter_fn(doc):
         # There shouldn't be any final punctuation marks (except periods) in the premise or the hypothesis.
         # They're supposed to be one single sentence in order to be concatenated properly in the prompt.
-        if any([punct in sent for punct in ["¡", "!", "?", "¿", "..."] for sent in [doc["premise"], doc["hypothesis"]]]):
+        if any([punct in sent for punct in ["¡", "!", "?", "¿", "...", ":", ";"] for sent in [doc["premise"], doc["hypothesis"]]]):
             return False
 
         return True

--- a/lm_eval/tasks/spanish_bench/xnli_es_spanish_bench.yaml
+++ b/lm_eval/tasks/spanish_bench/xnli_es_spanish_bench.yaml
@@ -4,7 +4,7 @@ dataset_path: xnli
 dataset_name: es
 output_type: multiple_choice
 doc_to_choice: '{{[premise+", ¿correcto? Sí, "+hypothesis,premise+", ¿correcto? Así
-  que, "+hypothesis,premise+", ¿correcto? No, "+hypothesis]}}'
+  que "+hypothesis,premise+", ¿correcto? No, "+hypothesis]}}'
 doc_to_text: ''
 target_delimiter: ''
 process_docs: !function utils.process_doc_nli


### PR DESCRIPTION
## Pull Request Checklist
- [x] The title of the PR is clear and concise.
- [x] I have provided a detailed description of the changes and the reason for the changes.
- [x] I have linked the related issue(s) in the description (if applicable).
- [x] I have followed the coding guidelines of this project.
- [x] I have ensured there are no breaking changes.
- [ ] I have updated related documentation (if applicable).
- [x] I have added reviewers, including at least one member of the MLOps team (@hrosegalb, @PaulNdrei, @ankush13r, @igorktech)

## Description

This PR contains some changes that fix formatting issues we have identified in our XNLI and TECA tasks, namely `xnli_ca`, `xnli_es_spanish_bench`, `xnli_gl`, `xnli_en` and `teca`. Specifically, I modified some task YAMLs and the `utils.py` file to update the `process_doc_nli` function and apply it to all our tasks equally.

I have also created a new task I named `xnli_en_iberobench` in order to have a version of this task for our internal use (like we did for `xnli_es_spanish_bench`) without modifying the original Harness' `xnli_en` task, which is part of its `xnli` group alongside a bunch of other languages.

These are the filtering and pre-processing steps I have added/modified:

* Filter out rows where the premise or hypothesis contain any of the following punctuation marks: `"¡", "!", "?", "¿", "...", ":", ";"`. We should do this because long premises or hypotheses with punctuation in the middle do not fit well into the template, which concatenates them into a sentence like `{premise}, correcte? Sí, {hypothesis}`, so we ended up with weird, grammatically-incorrect instances. We also have premises or hypothesis that end with `!`, `?` or `...` for the same reason.
* Always uppercase the first letter in the premise since it is always the start of the prompt. This fixes instances where sentences started with a lowercase letter.
* Ensure there is a single period in the end of the hypothesis so that all the prompts end in a period.
* Remove the comma that was after `Así que` in the Spanish task's `doc_to_choice`, because it is grammatically incorrect to start a sentence with "Así que, ...".

## Issue Link(s)
Closes #31 

## Testing

I have evaluated a couple of models on all of these tasks and manually verified (using regular expressions) that the instances are now correct, start with an uppercase letter, do not contain punctuation marks in the middle, and end with a period.


## :exclamation:  Important note

**This PR will effectively change all previously evaluated models' results on the tasks I've mentioned (`xnli_*` and `teca`).** It changes the pre-processing algorithm and the prompt template and filters out a lot of instances that contained undesired formatting. That is why I have added @jab13x and @ibaucells as reviewers and I ask you guys to **please check this PR carefully** and raise any objections you may have with the changes I've made; we can discuss them and make further modifications if necessary. I will merge the PR when everyone agrees with the new state of the tasks.