### PR TITLE
Add `flexible-extract` filter to `mgsm_direct_{ca,gl}`

### DIFF
--- a/lm_eval/tasks/catalan_bench/mgsm_direct_ca.yaml
+++ b/lm_eval/tasks/catalan_bench/mgsm_direct_ca.yaml
@@ -15,6 +15,12 @@ filter_list:
     filter:
       - function: remove_whitespace
       - function: take_first
+  - name: flexible-extract
+    filter:
+    - function: regex
+      group_select: -1
+      regex_pattern: (-?[$0-9.,]{2,})|(-?[0-9]+)
+    - function: take_first
 metric_list:
   - metric: exact_match
     aggregation: mean

--- a/lm_eval/tasks/galician_bench/mgsm_direct_gl.yaml
+++ b/lm_eval/tasks/galician_bench/mgsm_direct_gl.yaml
@@ -15,6 +15,12 @@ filter_list:
     filter:
       - function: remove_whitespace
       - function: take_first
+  - name: flexible-extract
+    filter:
+    - function: regex
+      group_select: -1
+      regex_pattern: (-?[$0-9.,]{2,})|(-?[0-9]+)
+    - function: take_first
 metric_list:
   - metric: exact_match
     aggregation: mean


### PR DESCRIPTION
## Pull Request Checklist
- [x] The title of the PR is clear and concise.
- [x] I have provided a detailed description of the changes and the reason for the changes.
- [x] I have linked the related issue(s) in the description (if applicable).
- [x] I have followed the coding guidelines of this project.
- [x] I have ensured there are no breaking changes.
- [ ] I have updated related documentation (if applicable). **n/a**
- [x] I have added reviewers, including at least one member of the MLOps team (@hrosegalb, @PaulNdrei, @ankush13r, @igorktech)

## Description
This PR adds the regex-based `flexible-extract` filter to the `mgsm_direct` tasks in Catalan and Galician. This filter was already available in the original `mgsm_direct_en` task as well as all tasks that import `tasks/mgsm/direct/direct_yaml`, such as `mgsm_direct_es_spanish_bench`, but not in the Catalan and Galician versions.

In the Basque tasks, `mgsm_direct_eu` and `mgsm_native_cot_eu`, there are already regex-based filters, `flexible-extract` in `mgsm_direct_eu` and `get-answer` in `mgsm_native_cot_eu`. As these were not implemented by us, I assume their regexes should be enough to get an answer from the model's output and I did not modify their filters.

## Issue Link(s)
Closes #30 

## Testing
I ran two tests successfully:
* Tested all MGSM tasks mentioned in this PR (including the ones I have not changed) with a sample of 20 instances.
```
hf (pretrained=/gpfs/projects/bsc88/hf-models/gemma-2-9b,trust_remote_code=True,trust_remote_code=True), gen_kwargs: (None), limit: 20.0, num_fewshot: 5, batch_size: 8
|           Tasks            |Version|     Filter      |n-shot|  Metric   |   |Value|   |Stderr|
|----------------------------|------:|-----------------|-----:|-----------|---|----:|---|-----:|
|mgsm_direct_ca              |      1|flexible-extract |     5|exact_match|↑  | 0.10|±  |0.0688|
|                            |       |remove_whitespace|     5|exact_match|↑  | 0.10|±  |0.0688|
|mgsm_direct_en              |      3|flexible-extract |     5|exact_match|↑  | 0.55|±  |0.1141|
|                            |       |remove_whitespace|     5|exact_match|↑  | 0.00|±  |0.0000|
|mgsm_direct_es_spanish_bench|      3|flexible-extract |     5|exact_match|↑  | 0.25|±  |0.0993|
|                            |       |remove_whitespace|     5|exact_match|↑  | 0.25|±  |0.0993|
|mgsm_direct_eu              |      1|flexible-extract |     5|exact_match|↑  | 0.25|±  |0.0993|
|                            |       |remove_whitespace|     5|exact_match|↑  | 0.25|±  |0.0993|
|mgsm_direct_gl              |      1|flexible-extract |     5|exact_match|↑  | 0.20|±  |0.0918|
|                            |       |remove_whitespace|     5|exact_match|↑  | 0.20|±  |0.0918|
|mgsm_native_cot_eu          |      1|get-answer       |     5|exact_match|↑  | 0.35|±  |0.1094|
```

* Tested `mgsm_direct_ca` and `mgsm_direct_gl` fully.
```
hf (pretrained=/gpfs/projects/bsc88/hf-models/gemma-2-2b,trust_remote_code=True,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: 8
|    Tasks     |Version|     Filter      |n-shot|  Metric   |   |Value|   |Stderr|
|--------------|------:|-----------------|-----:|-----------|---|----:|---|-----:|
|mgsm_direct_ca|      1|flexible-extract |     5|exact_match|↑  |0.060|±  |0.0151|
|              |       |remove_whitespace|     5|exact_match|↑  |0.044|±  |0.0130|
|mgsm_direct_gl|      1|flexible-extract |     5|exact_match|↑  |0.060|±  |0.0151|
|              |       |remove_whitespace|     5|exact_match|↑  |0.044|±  |0.0130|
```