### PR TITLE
Add tasks to IberoBench English group

### DIFF
--- a/lm_eval/tasks/iberobench_english/iberobench_english.yaml
+++ b/lm_eval/tasks/iberobench_english/iberobench_english.yaml
@@ -1,5 +1,20 @@
 group: iberobench_english
 task:
+  - belebele_eng_Latn
+  - arc_easy
+  - arc_challenge
+  - hellaswag
+  - copa
+  - xstorycloze_en
   - xnli_en_iberobench
+  - xquad_en
+  - openbookqa
+  - piqa
+  - social_iqa
+  - cola
+  - wnli
+  - truthfulqa
+  - paws_en
+  - mgsm_direct_en
 metadata:
   version: 1.0


### PR DESCRIPTION
## Pull Request Checklist
- [x] The title of the PR is clear and concise.
- [x] I have provided a detailed description of the changes and the reason for the changes.
- [x] I have linked the related issue(s) in the description (if applicable).
- [x] I have followed the coding guidelines of this project.
- [x] I have ensured there are no breaking changes.
- [x] I have updated related documentation (if applicable).
- [x] I have added reviewers, including at least one member of the MLOps team (@hrosegalb, @PaulNdrei, @ankush13r, @igorktech)

## Description

This PR fills the `iberobench_english` group with all the tasks that are listed under IberoBench English in Galtea. We decided to do this for consistency in groups of language-specific subtasks across Harness and Galtea, since IberoBench English was the only language-specific group not yet available as a group in Harness.

## Issue Link(s)
Closes #35 

## Testing

I ran an evaluation on `iberobench_english` dataset and checked that it included all the tasks on the list.
