### PR TITLE
Remove mmmlu_en from iberobench_english because it doesn't exist

### DIFF
--- a/lm_eval/tasks/iberobench_english/iberobench_english.yaml
+++ b/lm_eval/tasks/iberobench_english/iberobench_english.yaml
@@ -7,7 +7,6 @@ task:
   - copa
   - hellaswag
   - mgsm_direct_en
-  - mmmlu_en
   - openbookqa
   - paws_en
   - piqa

--- a/lm_eval/tasks/iberobench_english/iberobench_english.yaml
+++ b/lm_eval/tasks/iberobench_english/iberobench_english.yaml
@@ -7,6 +7,7 @@ task:
   - copa
   - hellaswag
   - mgsm_direct_en
+  - mmlu
   - openbookqa
   - paws_en
   - piqa


### PR DESCRIPTION
This PR corrects a small mistake I made when I included the MMMLU task and added "mmmlu_en" to IberoBench English, which is a non-existent task. There is no "mmmlu_en" because MMMLU is a multilingual version of MMLU and thus it's already available in English as the original "mmlu" task, which I've added to the bench then for consistency.