### PR TITLE
Filter out empty documents in NLI tasks

### DIFF
--- a/lm_eval/tasks/catalan_bench/utils.py
+++ b/lm_eval/tasks/catalan_bench/utils.py
@@ -16,6 +16,15 @@ def uppercase_first_letter(text):
 def process_doc_nli(dataset):
 
     def filter_fn(doc):
+        # Ensure that the premise and hypothesis are non-empty strings
+        if not (
+            isinstance(doc.get("premise"), str) and
+            isinstance(doc.get("hypothesis"), str) and
+            len(doc.get("premise").strip()) > 0 and
+            len(doc.get("hypothesis").strip()) > 0
+        ):
+            return False
+
         # There shouldn't be any final punctuation marks (except periods) in the premise or the hypothesis.
         # They're supposed to be one single sentence in order to be concatenated properly in the prompt.
         if any([punct in sent for punct in ["¡", "!", "?", "¿", "...", ":", ";"] for sent in [doc["premise"], doc["hypothesis"]]]):

--- a/lm_eval/tasks/galician_bench/utils.py
+++ b/lm_eval/tasks/galician_bench/utils.py
@@ -145,6 +145,15 @@ def preprocess_function_gen(examples):
 def process_doc_nli(dataset):
 
     def filter_fn(doc):
+        # Ensure that the premise and hypothesis are non-empty strings
+        if not (
+            isinstance(doc.get("sentence1"), str) and
+            isinstance(doc.get("sentence2"), str) and
+            len(doc.get("sentence1").strip()) > 0 and
+            len(doc.get("sentence2").strip()) > 0
+        ):
+            return False
+
         # There shouldn't be any final punctuation marks (except periods) in sentence1 or sentence2.
         # They're supposed to be one single sentence in order to be concatenated properly in the prompt.
         if any([punct in sent for punct in ["¡", "!", "?", "¿", "...", ":", ";"] for sent in [doc["sentence1"], doc["sentence2"]]]):

--- a/lm_eval/tasks/iberobench_english/utils.py
+++ b/lm_eval/tasks/iberobench_english/utils.py
@@ -10,6 +10,15 @@ def uppercase_first_letter(text):
 def process_doc_nli(dataset):
 
     def filter_fn(doc):
+        # Ensure that the premise and hypothesis are non-empty strings
+        if not (
+            isinstance(doc.get("premise"), str) and
+            isinstance(doc.get("hypothesis"), str) and
+            len(doc.get("premise").strip()) > 0 and
+            len(doc.get("hypothesis").strip()) > 0
+        ):
+            return False
+
         # There shouldn't be any final punctuation marks (except periods) in the premise or the hypothesis.
         # They're supposed to be one single sentence in order to be concatenated properly in the prompt.
         if any([punct in sent for punct in ["¡", "!", "?", "¿", "...", ":", ";"] for sent in [doc["premise"], doc["hypothesis"]]]):

--- a/lm_eval/tasks/spanish_bench/utils.py
+++ b/lm_eval/tasks/spanish_bench/utils.py
@@ -16,6 +16,15 @@ def uppercase_first_letter(text):
 def process_doc_nli(dataset):
 
     def filter_fn(doc):
+        # Ensure that the premise and hypothesis are non-empty strings
+        if not (
+            isinstance(doc.get("premise"), str) and
+            isinstance(doc.get("hypothesis"), str) and
+            len(doc.get("premise").strip()) > 0 and
+            len(doc.get("hypothesis").strip()) > 0
+        ):
+            return False
+
         # There shouldn't be any final punctuation marks (except periods) in the premise or the hypothesis.
         # They're supposed to be one single sentence in order to be concatenated properly in the prompt.
         if any([punct in sent for punct in ["¡", "!", "?", "¿", "...", ":", ";"] for sent in [doc["premise"], doc["hypothesis"]]]):

--- a/lm_eval/tasks/xnli_eu/utils.py
+++ b/lm_eval/tasks/xnli_eu/utils.py
@@ -9,6 +9,15 @@ def uppercase_first_letter(text):
 def process_doc_nli(dataset):
 
     def filter_fn(doc):
+        # Ensure that the premise and hypothesis are non-empty strings
+        if not (
+            isinstance(doc.get("premise"), str) and
+            isinstance(doc.get("hypothesis"), str) and
+            len(doc.get("premise").strip()) > 0 and
+            len(doc.get("hypothesis").strip()) > 0
+        ):
+            return False
+
         # There shouldn't be any final punctuation marks (except periods) in the premise or the hypothesis.
         # They're supposed to be one single sentence in order to be concatenated properly in the prompt.
         if any([punct in sent for punct in ["¡", "!", "?", "¿", "...", ":", ";"] for sent in [doc["premise"], doc["hypothesis"]]]):


### PR DESCRIPTION
## Pull Request Checklist
- [x] The title of the PR is clear and concise.
- [x] I have provided a detailed description of the changes and the reason for the changes.
- [ ] I have linked the related issue(s) in the description (if applicable).
- [x] I have followed the coding guidelines of this project.
- [x] I have ensured there are no breaking changes.
- [ ] I have updated related documentation (if applicable).
- [x] I have added reviewers, including at least one member of the MLOps team (@hrosegalb, @PaulNdrei, @ankush13r, @igorktech)

## Description

This PR fixes an issue with NLI tasks where datasets may have an empty string or null either in the `premise` or the `hypothesis` values, which later causes an error when `uppercase_first_letter` tries to access `text[0]`. We have run into this error recently because one of the datasets was updated and has this issue.

I simply added a clause in the `filter_fn` function in all of the `process_docs_nli` functions, in order for the first filter to be a check on whether these fields are strings and are not empty.

## Issue Link(s)

N/A

## Testing

I've run tests on the following NLI tasks to check that they run from beginning to end: `xnli_en_iberobench,xnli_es_spanish_bench,xnli_eu,xnli_gl,xnli_ca,teca`