### PR TITLE
Add EQBench spanish and catalan versions

### DIFF
--- a/lm_eval/tasks/catalan_bench/catalan_bench.yaml
+++ b/lm_eval/tasks/catalan_bench/catalan_bench.yaml
@@ -9,6 +9,7 @@ task:
     - cocoteros_va
     - copa_ca
     - coqcat
+    - eqbench_ca
     - flores_ca
     - mgsm_direct_ca
     - openbookqa_ca

--- a/lm_eval/tasks/eq_bench/eqbench_ca.yaml
+++ b/lm_eval/tasks/eq_bench/eqbench_ca.yaml
@@ -1,0 +1,20 @@
+task: eqbench_ca
+dataset_path: BSC-LT/EQ-bench_ca
+output_type: generate_until
+validation_split: test
+doc_to_text: prompt
+doc_to_target: reference_answer_fullscale
+process_results: !function utils.calculate_score_fullscale
+generation_kwargs:
+  do_sample: false
+  temperature: 0.0
+  max_gen_toks: 80
+metric_list:
+  - metric: eqbench
+    aggregation: mean
+    higher_is_better: true
+  - metric: percent_parseable
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/eq_bench/eqbench_es.yaml
+++ b/lm_eval/tasks/eq_bench/eqbench_es.yaml
@@ -1,0 +1,20 @@
+task: eqbench_es
+dataset_path: BSC-LT/EQ-bench_es
+output_type: generate_until
+validation_split: test
+doc_to_text: prompt
+doc_to_target: reference_answer_fullscale
+process_results: !function utils.calculate_score_fullscale
+generation_kwargs:
+  do_sample: false
+  temperature: 0.0
+  max_gen_toks: 80
+metric_list:
+  - metric: eqbench
+    aggregation: mean
+    higher_is_better: true
+  - metric: percent_parseable
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/spanish_bench/spanish_bench.yaml
+++ b/lm_eval/tasks/spanish_bench/spanish_bench.yaml
@@ -5,6 +5,7 @@ task:
   - copa_es
   - esbbq
   - escola
+  - eqbench_es
   - flores_es
   - mgsm_direct_es_spanish_bench
   - mmmlu_es


### PR DESCRIPTION
## Pull Request Checklist
- [x] The title of the PR is clear and concise.
- [x] I have provided a detailed description of the changes and the reason for the changes.
- [ ] I have linked the related issue(s) in the description (if applicable).
- [x] I have followed the coding guidelines of this project.
- [x] I have ensured there are no breaking changes.
- [x] I have updated related documentation (if applicable).
- [x] I have added reviewers, including at least one member of the MLOps team (@hrosegalb, @PaulNdrei, @ankush13r, @igorktech)

## New Task Checklist
- [x] I have ensured that the dataset used in the task has been human annotated or translated, or that, if synthetic, a strong and reliable human revision has taken place.
- [x]  I have explored existing Harness tasks to check the types of prompts, metrics and setups used in similar tasks, and either adopted the same for my task or have a strong reason(s) not to do it (please provide justification in description).
- [x]  I have reviewed the dataset structure and contents to ensure that the prompt used does not impact the quality of the input given to the models.
- [x]  If errors were detected, I have added suitable pre- or post-processing to the task.
- [x]  I have tested that my task runs from beginning to end.
- [x]  I have reviewed the inputs given to the models to ensure that instructions are natural, grammatical, and as I expected overall (e.g., punctuation and capitalization are used correctly, the few-shot context is not truncated, etc.).
- [x]  I have reviewed the outputs of the evaluations of the models, making sure that metrics and other aspects of the setup work as I expected.
- [x]  If my task is in Spanish, Catalan, Galician, Basque, Portuguese or English, I have talked to Javier Aula-Blasco regarding the possibility of adding it to one of the Benches.

## Description
`EQ-Bench_es_ca` are translated and linguistically adapted versions of the original EQ-Bench dataset into Spanish and Catalan. Their design respond to the need to adapt the emotional detection capabilities of multilingual models, recognizing that the expression and perception of emotions varies significantly across languages.
They're directly adapted from the original EQBench dataset, preserving its form, prompt structure and setup. Only a few minor corrections were made to the original JSONL file, such as fixing the index numbers (incorrectly stored as strings) and converting the preference answer scores placeholders to strings where required.

## Issue Link(s)
Not applicable

## Testing
`eq-bench_es` and `eq-bench_ca` were individually tested using the BSC Harness with FLOR-760M. Both datasets were also evaluated inside the `spanish_bench` and `catalan_bench` groups respectively.

