### PR TITLE
Fix error in NLI tasks preprocessing

### DIFF
--- a/lm_eval/tasks/catalan_bench/utils.py
+++ b/lm_eval/tasks/catalan_bench/utils.py
@@ -40,6 +40,10 @@ def process_doc_nli(dataset):
         # Remove periods from the end of the premise
         doc["premise"] = doc["premise"].rstrip(".")
 
+        # Drop the document if nothing is left
+        if (len(doc["premise"]) == 0) or (len(doc["hypothesis"]) == 0):
+            return None
+
         # Lowercase the first letter in the hypothesis
         doc["hypothesis"] = lowercase_first_letter(doc["hypothesis"])
 

--- a/lm_eval/tasks/galician_bench/utils.py
+++ b/lm_eval/tasks/galician_bench/utils.py
@@ -169,6 +169,10 @@ def process_doc_nli(dataset):
         # Remove final periods in sentence1
         doc["sentence1"] = doc["sentence1"].rstrip(".")
 
+        # Drop the document if nothing is left
+        if (len(doc["sentence1"]) == 0) or (len(doc["sentence2"]) == 0):
+            return None
+
         # Lowercase the first letter in sentence2
         doc["sentence2"] = lowercase_first_letter(doc["sentence2"])
 

--- a/lm_eval/tasks/iberobench_english/utils.py
+++ b/lm_eval/tasks/iberobench_english/utils.py
@@ -34,6 +34,10 @@ def process_doc_nli(dataset):
         # Remove periods from the end of the premise
         doc["premise"] = doc["premise"].rstrip(".")
 
+        # Drop the document if nothing is left
+        if (len(doc["premise"]) == 0) or (len(doc["hypothesis"]) == 0):
+            return None
+
         # Lowercase the first letter in the hypothesis
         doc["hypothesis"] = lowercase_first_letter(doc["hypothesis"])
 

--- a/lm_eval/tasks/spanish_bench/utils.py
+++ b/lm_eval/tasks/spanish_bench/utils.py
@@ -40,6 +40,10 @@ def process_doc_nli(dataset):
         # Remove periods from the end of the premise
         doc["premise"] = doc["premise"].rstrip(".")
 
+        # Drop the document if nothing is left
+        if (len(doc["premise"]) == 0) or (len(doc["hypothesis"]) == 0):
+            return None
+
         # Lowercase the first letter in the hypothesis
         doc["hypothesis"] = lowercase_first_letter(doc["hypothesis"])
 

--- a/lm_eval/tasks/xnli_eu/utils.py
+++ b/lm_eval/tasks/xnli_eu/utils.py
@@ -33,6 +33,10 @@ def process_doc_nli(dataset):
         # Remove periods from the end of the premise
         doc["premise"] = doc["premise"].rstrip(".")
 
+        # Drop the document if nothing is left
+        if (len(doc["premise"]) == 0) or (len(doc["hypothesis"]) == 0):
+            return None
+
         # Lowercase the first letter in the hypothesis
         doc["hypothesis"] = lowercase_first_letter(doc["hypothesis"])
 


### PR DESCRIPTION
## Pull Request Checklist
- [x] The title of the PR is clear and concise.
- [x] I have provided a detailed description of the changes and the reason for the changes.
- [ ] I have linked the related issue(s) in the description (if applicable).
- [x] I have followed the coding guidelines of this project.
- [x] I have ensured there are no breaking changes.
- [x] I have updated related documentation (if applicable).
- [x] I have added reviewers, including at least one member of the MLOps team (@hrosegalb, @PaulNdrei, @ankush13r, @igorktech)

## Description
This PR fixes an error I've found with the preprocessing we do for the NLI tasks. There was a scenario I caught with this document:
```
{'premise': '. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .', 'hypothesis': 'Immigrazioari eta nazionalitateari buruzko Legeak ez du atzerritarrentzako xedapenik aurreikusten.', 'label': 2}
```
As the premise only contains periods, it would pass the first filter (`filter_fn`) but then would be stripped to nothing at `doc["premise"].rstrip(".")` and would raise an exception in `uppercase_first_letter(doc["premise"])`. I've added a conditional after the lstrip to check that there is still something left in both the premise and hypothesis strings, and otherwise, return None, which ignores this document and lets the task finish successfully with the other docs.

## Issue Link(s)
N/A

## Testing
I ran a test with all of the tasks that use this preprocessing function, with all of their instances, and saw that they finished successfully without errors.
```
hf (pretrained=/gpfs/projects/bsc88/hf-models/FLOR-760M,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto (64)
|        Tasks        |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|---------------------|------:|------|-----:|------|---|-----:|---|-----:|
|teca                 |      1|none  |     5|acc   |↑  |0.4271|±  |0.0111|
|xnli_ca              |      1|none  |     5|acc   |↑  |0.4800|±  |0.0106|
|xnli_en_iberobench   |      1|none  |     5|acc   |↑  |0.4549|±  |0.0105|
|xnli_es_spanish_bench|      1|none  |     5|acc   |↑  |0.4436|±  |0.0107|
|xnli_eu              |      1|none  |     5|acc   |↑  |0.3333|±  |0.0072|
|xnli_eu_native       |      1|none  |     5|acc   |↑  |0.3527|±  |0.0198|
|xnli_gl              |      1|none  |     5|acc   |↑  |0.4235|±  |0.0074|
```
