### PR TITLE
Fix MGSM generation end criteria in IberoBench languages

### DIFF
--- a/lm_eval/tasks/basque_bench/mgsm_cot_native_eu.yaml
+++ b/lm_eval/tasks/basque_bench/mgsm_cot_native_eu.yaml
@@ -8,14 +8,11 @@ training_split: train
 test_split: test
 target_delimiter: " "
 generation_kwargs:
+  do_sample: false
   until:
-    - "\n\n"
-    - "\n"
     - "Galdera:"
     - </s>
     - <|im_end|>
-  do_sample: false
-  temperature: 0.0
 filter_list:
   - name: "get-answer"
     filter:

--- a/lm_eval/tasks/basque_bench/mgsm_direct_eu.yaml
+++ b/lm_eval/tasks/basque_bench/mgsm_direct_eu.yaml
@@ -8,14 +8,11 @@ training_split: train
 test_split: test
 target_delimiter: " "
 generation_kwargs:
+  do_sample: false
   until:
-    - "\n\n"
-    - "\n"
     - "Galdera:"
     - </s>
     - <|im_end|>
-  do_sample: false
-  temperature: 0.0
 filter_list:
   - name: remove_whitespace
     filter:

--- a/lm_eval/tasks/catalan_bench/mgsm_direct_ca.yaml
+++ b/lm_eval/tasks/catalan_bench/mgsm_direct_ca.yaml
@@ -7,9 +7,11 @@ training_split: train
 test_split: test
 target_delimiter: ""
 generation_kwargs:
+  do_sample: false
   until:
-    - "\n\n"
-    - "\n"
+  - 'Pregunta:'
+  - </s>
+  - <|im_end|>
 filter_list:
   - name: remove_whitespace
     filter:

--- a/lm_eval/tasks/galician_bench/mgsm_direct_gl.yaml
+++ b/lm_eval/tasks/galician_bench/mgsm_direct_gl.yaml
@@ -7,9 +7,11 @@ training_split: train
 test_split: test
 target_delimiter: ""
 generation_kwargs:
+  do_sample: false
   until:
-    - "\n\n"
-    - "\n"
+    - "Pregunta:"
+    - </s>
+    - <|im_end|>
 filter_list:
   - name: remove_whitespace
     filter:

--- a/lm_eval/tasks/spanish_bench/mgsm_direct_es_spanish_bench.yaml
+++ b/lm_eval/tasks/spanish_bench/mgsm_direct_es_spanish_bench.yaml
@@ -1,9 +1,10 @@
 include: ../mgsm/direct/mgsm_direct_es.yaml
 doc_to_target: '{{answer_number|string}}'
 doc_to_text: '{% if answer is not none %}{{question+"\nRespuesta: "}}{% else %}{{"Pregunta: "+question+"\nRespuesta: "}}{% endif %}'
-generation_kwargs:
-  until:
-    - "\n\n"
-    - "\n"
-
 task: mgsm_direct_es_spanish_bench
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'Pregunta:'
+  - </s>
+  - <|im_end|>


### PR DESCRIPTION
## Pull Request Checklist
- [x] The title of the PR is clear and concise.
- [x] I have provided a detailed description of the changes and the reason for the changes.
- [x] I have linked the related issue(s) in the description (if applicable).
- [x] I have followed the coding guidelines of this project.
- [x] I have ensured there are no breaking changes.
- [x] I have updated related documentation (if applicable).
- [x] I have added reviewers, including at least one member of the MLOps team (@hrosegalb, @PaulNdrei, @ankush13r, @igorktech)

## Description

This PR fixes the implementation of MGSM tasks in IberoBench languages because it was pointed out by the post-training team that generation currently stops at multiple criteria which include `\n` and `\n\n`. This was causing Harness to cut off generation when the model includes a line-break in its answer, which is very common nowadays by instruction-tuned models that will often jump a line before providing the actual answer. Therefore, we make the following modifications:

* Generation should only stop at </s>, <|im_end|> and the question string
* Remove criteria to stop on line breaks as it cuts off generation when the model adds a line break gefore the answer
* Remove temperature argument as is not compatible with do_sample=false

(The last one was just to avoid a warning that comes up from `transformers` when the `temperature` parameter is in the task YAML, which is incompatible with greedy decoding.)

## Issue Link(s)
N/A

## Testing

I've tested a recent checkpoint given to us by the post-training team in the MGSM tasks.
```
hf (pretrained=/gpfs/scratch/bsc88/text/projects/synthetic_preference_data/trainings/13_40b_sft_sc_lc_final_mix1_no-cl/training/00__2025_09_28_14_15,trust_remote_code=True,parallelize=True), gen_kwargs: (None), limit: None, num_fewshot: 0, batch_size: 1
|           Tasks            |Version|     Filter      |n-shot|  Metric   |   |Value|   |Stderr|
|----------------------------|------:|-----------------|-----:|-----------|---|----:|---|-----:|
|mgsm_direct_ca              |      1|flexible-extract |     0|exact_match|↑  |0.348|±  |0.0302|
|                            |       |remove_whitespace|     0|exact_match|↑  |0.000|±  |0.0000|
|mgsm_direct_es_spanish_bench|      3|flexible-extract |     0|exact_match|↑  |0.396|±  |0.0310|
|                            |       |remove_whitespace|     0|exact_match|↑  |0.000|±  |0.0000|
|mgsm_direct_eu              |      1|flexible-extract |     0|exact_match|↑  |0.212|±  |0.0259|
|                            |       |remove_whitespace|     0|exact_match|↑  |0.000|±  |0.0000|
|mgsm_direct_gl              |      1|flexible-extract |     0|exact_match|↑  |0.340|±  |0.0300|
|                            |       |remove_whitespace|     0|exact_match|↑  |0.000|±  |0.0000|
|mgsm_native_cot_eu          |      1|get-answer       |     0|exact_match|↑  |0.000|±  |0.0000|
```

We found that scores have improved significantly in nearly all the languages, except for `mgsm_direct_eu`, which we are not specifically concerned about because this task has a different `flexible-extract` regex than the rest and thus it may not behave the same. Upon looking at the samples, we are satisfied that at least the generation is "complete", i.e. the model's entire response is captured rather than cut off at line breaks, and so the filter is able to pick up its final numerical response.

For example, looking at `doc_id=4`:
**Previous response** (`/gpfs/projects/bsc88/mlops-lm-evaluation-harness/production/results/00__2025_09_28_14_15/0-shot/samples_mgsm_direct_eu_2025-09-29T10-30-39.074838.jsonl`):
`Wendik bere oilaskoei 5 katilukada janari eman behar dizkie eguneko azken jatorduan.` (_Wendi needs to give her chickens 5 bowls of food at the last meal of the day._)
**New response** (`/gpfs/projects/bsc88/mlops-lm-evaluation-harness/fix_mgsm_end_chars/results/00__2025_09_28_14_15/samples_mgsm_direct_eu_2025-10-16T12-05-19.388603.jsonl`):
`Wendik bere oilaskoei 5 katilukada janari eman behar dizkie eguneko azken jatorduan. \nEgunero, 15 katilukada + 25 katilukada = 40 katilukada janari ematen dizkie bere 20 oilaskoei. \n40 katilukada 20 oilaskoentzat = 2 katilukada oilasko bakoitzeko. \nEgunero, 3 katilukada 20 oilaskoentzat = 3 katilukada / 20 = 0,15 katilukada oilasko bakoitzeko. \nArratsaldean, 25 katilukada 20 oilaskoentzat = 25 katilukada / 20 = 1,25 katilukada oilasko bakoitzeko. \nEguneko azken jatorduan, 2 katilukada + 1,25 katilukada = 3,25 katilukada oilasko bakoitzeko. \n20 oilaskoentzat, 3,25 katilukada x 20 = 65 katilukada.` (_Wendi needs to feed her chickens 5 cups of food at the last meal of the day. \nEvery day, she feeds her 20 chickens 15 cups + 25 cups = 40 cups of food. \n40 cups for 20 chickens = 2 cups per chicken. \nEvery day, 3 cups for 20 chickens = 3 cups / 20 = 0.15 cups per chicken. \nIn the evening, 25 cups for 20 chickens = 25 cups / 20 = 1.25 cups per chicken. \nAt the last meal of the day, 2 cups + 1.25 cups = 3.25 cups per chicken. \nFor 20 chickens, 3.25 cups x 20 = 65 cups._)

The response is still wrong because the correct answer is 20, but at least with the new criteria the generation includes the entire response of the model, and picks up its final (albeit incorrect) response of 65 cups. With the old criteria, it stopped at the first line, which was only the start of the model's answer.

## Note

We are asking to merge this into `production` first because the post-training team wants to use this task to evaluate their checkpoints, but we will also soon open a PR to EleutherAI's Harness to include this change.