### PR TITLE
Add `iberobench_inst` task variants to evaluate new aligned models

### DIFF
--- a/lm_eval/tasks/catalan_bench/utils.py
+++ b/lm_eval/tasks/catalan_bench/utils.py
@@ -85,7 +85,6 @@ def process_results_coqcat(doc, results):
     else:
         em_sum += max(squad_metrics.compute_exact(a, pred) for a in gold_list)
         f1_sum += max(squad_metrics.compute_f1(a, pred) for a in gold_list)
-    # import code; code.interact(local=dict(globals(), **locals()))
     return {
         "em": em_sum / max(1, len(gold_list)),
         "f1": f1_sum / max(1, len(gold_list)),
@@ -95,7 +94,6 @@ def process_results_coqcat(doc, results):
 def process_results_qa(doc, results):
     preds = results[0]
     reference = doc["answers"][0]["text"]
-    # import code; code.interact(local=dict(globals(), **locals()))
     f1_sum = squad_metrics.compute_f1(reference, preds)
     exact_match = squad_metrics.compute_exact(reference, preds)
     return {"f1": f1_sum, "exact_match": exact_match}

--- a/lm_eval/tasks/galician_bench/utils.py
+++ b/lm_eval/tasks/galician_bench/utils.py
@@ -1,11 +1,9 @@
 import re
-from itertools import product
 
 import datasets
 import evaluate
 import numpy as np
 import sacrebleu
-import transformers.data.metrics.squad_metrics as squad_metrics
 from rouge_score import rouge_scorer, scoring
 
 from lm_eval.utils import general_detokenize
@@ -97,7 +95,6 @@ def rouge1_agg(items):
     refs = list(zip(*items))[0]
     preds = list(zip(*items))[1]
     rouge_scorer = evaluate.load("rouge")
-    # import code; code.interact(local=dict(globals(), **locals()))
     return rouge_scorer.compute(predictions=preds, references=refs)["rouge1"]
 
 

--- a/lm_eval/tasks/iberobench_inst/README.md
+++ b/lm_eval/tasks/iberobench_inst/README.md
@@ -1,0 +1,11 @@
+### IberoBench, instructed
+
+IberoBench task variants that are adapted for instruction-tuned and/or aligned models. The changes mostly consist in different stop criteria (`generation_kwargs.until`) and generation limit (`generation_kwargs.max_gen_toks`) to avoid issues where generation would be cut in the middle due to the model's usage of `\n\n` between paragraphs, and incomplete generations due to limits that were too short for aligned models that provide CoT.
+
+All the tasks retain the same name but suffixed by `_inst` to reflect the variation in `generation_kwargs`. These variants should only be used to evaluate instruction-tuned/aligned models and may not even be appropriate for all instruction-tuned models; look at generated samples to ensure that these settings allow the model to generate complete answers (if it is able to do so).
+
+* **`mgsm_native_cot_eu_inst`**, **`mgsm_direct_{ca,gl,en,es_spanish_bench}_inst`**: Longer `max_gen_toks` (8191); no generation stop criteria. Remove all criteria to stop on *`Question:`* strings, `</s>` or `<|im_end|>`.
+* **`cabreu_inst`** tag, with tasks **`cabreu_{abstractive, extractive, extreme}_inst`**: Longer `max_gen_toks` (8191); no generation stop criteria (modified in a new `_cabreu_inst_common_yaml`).
+* **`summarization_gl_inst`**, **`xlsum_es_inst`**: Longer `max_gen_toks` (1024); no generation stop criteria.
+* **`xsum_inst`**: New implementation of `xsum` as a regular summarization task, without using `unitxt`. Different prompt that asks for a *"One-sentence summary"*; use the same processing function as `summarization_gl` (`process_summarization` from `galician_bench/utils.py`); longer `max_gen_toks` (1024); no stop criteria.
+* **`xquad_{ca,es,en}_inst`**: Stop only on `\n\n` and not on `\n`. (`xquad_{en,es}_inst` import from `_xquad_inst_common_yaml`, while `xquad_ca_inst` is defined on its own.)

--- a/lm_eval/tasks/iberobench_inst/_cabreu_inst_common_yaml
+++ b/lm_eval/tasks/iberobench_inst/_cabreu_inst_common_yaml
@@ -1,0 +1,21 @@
+tag: cabreu_inst
+dataset_path: projecte-aina/caBreu
+dataset_name: null
+output_type: generate_until
+test_split: test
+training_split: train
+validation_split: validation
+process_docs: !function ../catalan_bench/utils.process_doc_cabreu
+generation_kwargs:
+  do_sample: false
+  max_gen_toks: 8191
+  until: []
+metric_list:
+  - metric: bleu
+    aggregation: bleu
+    higher_is_better: true
+  - metric: !function ../catalan_bench/utils.rouge1
+    aggregation: !function ../catalan_bench/utils.rouge1_agg
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/iberobench_inst/_xquad_inst_common_yaml
+++ b/lm_eval/tasks/iberobench_inst/_xquad_inst_common_yaml
@@ -1,0 +1,24 @@
+tag: xquad_inst
+task: null
+dataset_path: xquad
+dataset_name: null
+output_type: generate_until
+validation_split: validation
+doc_to_text: null
+doc_to_target: '{{answers["text"][0]}}'
+process_results: !function ../xquad/utils.process_results_qa
+target_delimiter: ' '
+generation_kwargs:
+  until:
+    - "\n\n"
+  do_sample: false
+  temperature: 0.0
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+  - metric: f1
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/iberobench_inst/cabreu_abstractive_inst.yaml
+++ b/lm_eval/tasks/iberobench_inst/cabreu_abstractive_inst.yaml
@@ -1,0 +1,8 @@
+include: _cabreu_inst_common_yaml
+task: cabreu_abstractive_inst
+description: "Examina el text següent i genera'n un resum abstractiu, expressant el significat del text original d'una manera més natural i concisa.\n"
+doc_to_text: >-
+  Text: {{content}}
+
+  Resum:
+doc_to_target: '{{summaries["abstractive"]["a1"]}}'

--- a/lm_eval/tasks/iberobench_inst/cabreu_extractive_inst.yaml
+++ b/lm_eval/tasks/iberobench_inst/cabreu_extractive_inst.yaml
@@ -1,0 +1,8 @@
+include: _cabreu_inst_common_yaml
+task: cabreu_extractive_inst
+description: "Examina el text següent i genera'n un resum extractiu, utilitzant les frases o oracions més rellevants del text original.\n"
+doc_to_text: >-
+  Text: {{content}}
+
+  Resum:
+doc_to_target: '{{summaries["extractive"]["a1"]}}'

--- a/lm_eval/tasks/iberobench_inst/cabreu_extreme_inst.yaml
+++ b/lm_eval/tasks/iberobench_inst/cabreu_extreme_inst.yaml
@@ -1,0 +1,8 @@
+include: _cabreu_inst_common_yaml
+task: cabreu_extreme_inst
+description: "Examina el text següent i genera'n un resum que sigui el més concís possible i que preservi el significat del text original.\n"
+doc_to_text: >-
+  Text: {{content}}
+
+  Resum:
+doc_to_target: '{{summaries["extreme"]["a1"]}}'

--- a/lm_eval/tasks/iberobench_inst/mgsm_direct_ca_inst.yaml
+++ b/lm_eval/tasks/iberobench_inst/mgsm_direct_ca_inst.yaml
@@ -1,0 +1,31 @@
+task: mgsm_direct_ca_inst
+dataset_path: projecte-aina/mgsm_ca
+doc_to_target: '{{answer_number|string}}'
+doc_to_text: '{% if answer != None %}{{question + "\nResposta: "}}{% else %}{{"Pregunta: " + question + "\nResposta: "}}{% endif %}'
+output_type: generate_until
+training_split: train
+test_split: test
+target_delimiter: ""
+generation_kwargs:
+  do_sample: false
+  max_gen_toks: 8191
+  until: []
+filter_list:
+  - name: remove_whitespace
+    filter:
+      - function: remove_whitespace
+      - function: take_first
+  - name: flexible-extract
+    filter:
+    - function: regex
+      group_select: -1
+      regex_pattern: (-?[$0-9.,]{2,})|(-?[0-9]+)
+    - function: take_first
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+    ignore_case: true
+    ignore_punctuation: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/iberobench_inst/mgsm_direct_en_inst.yaml
+++ b/lm_eval/tasks/iberobench_inst/mgsm_direct_en_inst.yaml
@@ -1,0 +1,9 @@
+dataset_name: en
+doc_to_target: '{% if answer is not none %}{{answer[21:]}}{% else %}{{answer_number|string}}{% endif %}'
+doc_to_text: '{% if answer is not none %}{{question+"\nAnswer:"}}{% else %}{{"Question: "+question+"\nAnswer:"}}{% endif %}'
+generation_kwargs:
+  do_sample: false
+  max_gen_toks: 8191
+  until: []
+include: ../mgsm/direct/mgsm_direct_es.yaml
+task: mgsm_direct_en_inst

--- a/lm_eval/tasks/iberobench_inst/mgsm_direct_es_spanish_bench_inst.yaml
+++ b/lm_eval/tasks/iberobench_inst/mgsm_direct_es_spanish_bench_inst.yaml
@@ -1,0 +1,8 @@
+include: ../mgsm/direct/mgsm_direct_es.yaml
+doc_to_target: '{{answer_number|string}}'
+doc_to_text: '{% if answer is not none %}{{question+"\nRespuesta: "}}{% else %}{{"Pregunta: "+question+"\nRespuesta: "}}{% endif %}'
+task: mgsm_direct_es_spanish_bench_inst
+generation_kwargs:
+  do_sample: false
+  max_gen_toks: 8191
+  until: []

--- a/lm_eval/tasks/iberobench_inst/mgsm_direct_eu_inst.yaml
+++ b/lm_eval/tasks/iberobench_inst/mgsm_direct_eu_inst.yaml
@@ -1,0 +1,34 @@
+task: mgsm_direct_eu_inst
+dataset_path: HiTZ/MGSM-eu
+dataset_name: null
+doc_to_target: '{{answer_number|string}}'
+doc_to_text: '{% if answer is not none %}{{question+"\nErantzuna:"}}{% else %}{{"Galdera: "+question+"\nErantzuna:"}}{% endif %}'
+output_type: generate_until
+training_split: train
+test_split: test
+target_delimiter: " "
+generation_kwargs:
+  do_sample: false
+  max_gen_toks: 8191
+  until: []
+filter_list:
+  - name: remove_whitespace
+    filter:
+      - function: remove_whitespace
+      - function: take_first
+  - name: flexible-extract
+    filter:
+    - function: regex
+      group_select: -1
+      regex_pattern: (-?[0-9]+([ .,][0-9.,]+)?)
+    - function: take_first
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+    ignore_case: true
+    ignore_punctuation: true
+    regexes_to_ignore:
+      - " "
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/iberobench_inst/mgsm_direct_gl_inst.yaml
+++ b/lm_eval/tasks/iberobench_inst/mgsm_direct_gl_inst.yaml
@@ -1,0 +1,31 @@
+task: mgsm_direct_gl_inst
+dataset_path: proxectonos/mgsm_gl
+doc_to_target: '{{answer_number|string}}'
+doc_to_text: '{% if answer != None %}{{question + "\nResposta: "}}{% else %}{{"Pregunta: " + question + "\nResposta: "}}{% endif %}'
+output_type: generate_until
+training_split: train
+test_split: test
+target_delimiter: ""
+generation_kwargs:
+  do_sample: false
+  max_gen_toks: 8191
+  until: []
+filter_list:
+  - name: remove_whitespace
+    filter:
+      - function: remove_whitespace
+      - function: take_first
+  - name: flexible-extract
+    filter:
+    - function: regex
+      group_select: -1
+      regex_pattern: (-?[$0-9.,]{2,})|(-?[0-9]+)
+    - function: take_first
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+    ignore_case: true
+    ignore_punctuation: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/iberobench_inst/mgsm_native_cot_eu_inst.yaml
+++ b/lm_eval/tasks/iberobench_inst/mgsm_native_cot_eu_inst.yaml
@@ -1,0 +1,29 @@
+task: mgsm_native_cot_eu_inst
+dataset_path: HiTZ/MGSM-eu
+dataset_name: null
+doc_to_target: '{% if answer is not none %}{{answer[27:]}}{% else %}{{answer_number|string}}{%endif %}'
+doc_to_text: '{% if answer is not none %}{{question+"\nErantzuna urratsez urrats:"}}{% else %}{{"Galdera: "+question+"\nErantzuna urratsez urrats:"}}{% endif %}'
+output_type: generate_until
+training_split: train
+test_split: test
+target_delimiter: " "
+generation_kwargs:
+  do_sample: false
+  max_gen_toks: 8191
+  until: []
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        regex_pattern: "Erantzuna [$%]? ?(-?[0-9]+([ .,][0-9.,]+)?) ?[$%]? da"
+      - function: "take_first"
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+    ignore_case: true
+    ignore_punctuation: true
+    regexes_to_ignore:
+      - " "
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/iberobench_inst/summarization_gl_inst.yaml
+++ b/lm_eval/tasks/iberobench_inst/summarization_gl_inst.yaml
@@ -1,0 +1,24 @@
+task: summarization_gl_inst
+dataset_path: proxectonos/summarization_gl
+output_type: generate_until
+test_split: test
+training_split: train
+validation_split: validation
+fewshot_split: train
+process_docs: !function ../galician_bench/utils.process_summarization
+doc_to_text: 'Texto: {{text}}
+
+  Resumo:'
+doc_to_target: '{{summary}}'
+generation_kwargs:
+  until: []
+  max_gen_toks: 1024
+metric_list:
+  - metric: bleu
+    aggregation: bleu
+    higher_is_better: true
+  - metric: !function ../galician_bench/utils.rouge1
+    aggregation: !function ../galician_bench/utils.rouge1_agg
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/iberobench_inst/utils.py
+++ b/lm_eval/tasks/iberobench_inst/utils.py
@@ -1,0 +1,28 @@
+import re
+
+import evaluate
+
+
+def process_xsum(dataset):
+    def _process_doc(doc):
+        # Remove double spaces
+        doc["document"] = re.sub(r" +", " ", doc["document"])
+        doc["summary"] = re.sub(r" +", " ", doc["summary"])
+        return doc
+
+    return dataset.map(lambda doc: _process_doc(doc))
+
+def rouge1(items):
+    """
+    # passthrough for efficiency
+    """
+    return items
+
+def rouge1_agg(items):
+    """
+    Higher is better
+    """
+    refs = list(zip(*items))[0]
+    preds = list(zip(*items))[1]
+    rouge_scorer = evaluate.load("rouge")
+    return rouge_scorer.compute(predictions=preds, references=refs)["rouge1"]

--- a/lm_eval/tasks/iberobench_inst/xlsum_es_inst.yaml
+++ b/lm_eval/tasks/iberobench_inst/xlsum_es_inst.yaml
@@ -1,0 +1,25 @@
+task: xlsum_es_inst
+dataset_path: csebuetnlp/xlsum
+dataset_name: spanish
+doc_to_text: 'Texto: {{text}}
+
+  Resumen:'
+doc_to_target: '{{summary}}'
+output_type: generate_until
+test_split: test
+training_split: train
+validation_split: validation
+fewshot_split: train
+process_docs: !function ../spanish_bench/utils.process_xlsum
+generation_kwargs:
+  until: []
+  max_gen_toks: 1024
+metric_list:
+  - metric: bleu
+    aggregation: bleu
+    higher_is_better: true
+  - metric: !function ../spanish_bench/utils.rouge1
+    aggregation: !function ../spanish_bench/utils.rouge1_agg
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/iberobench_inst/xquad_ca_inst.yaml
+++ b/lm_eval/tasks/iberobench_inst/xquad_ca_inst.yaml
@@ -1,0 +1,24 @@
+task: xquad_ca_inst
+dataset_path: projecte-aina/xquad-ca
+dataset_name: null
+output_type: generate_until
+doc_to_text: "Context: {{context}}\n\nPregunta: {{question}}\n\nResposta:"
+doc_to_target: '{{answers[0]["text"]}}'
+validation_split: null
+test_split: test
+target_delimiter: ' '
+process_results: !function ../catalan_bench/utils.process_results_qa
+generation_kwargs:
+  until:
+    - "\n\n"
+  do_sample: false
+  temperature: 0.0
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+  - metric: f1
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/iberobench_inst/xquad_en_inst.yaml
+++ b/lm_eval/tasks/iberobench_inst/xquad_en_inst.yaml
@@ -1,0 +1,4 @@
+include: _xquad_inst_common_yaml
+task: xquad_en_inst
+dataset_name: xquad.es
+doc_to_text: "Contexto: {{context}}\n\nPregunta: {{question}}\n\nRespuesta:"

--- a/lm_eval/tasks/iberobench_inst/xquad_es_inst.yaml
+++ b/lm_eval/tasks/iberobench_inst/xquad_es_inst.yaml
@@ -1,0 +1,4 @@
+include: _xquad_inst_common_yaml
+task: xquad_es_inst
+dataset_name: xquad.es
+doc_to_text: "Contexto: {{context}}\n\nPregunta: {{question}}\n\nRespuesta:"

--- a/lm_eval/tasks/iberobench_inst/xsum_inst.yaml
+++ b/lm_eval/tasks/iberobench_inst/xsum_inst.yaml
@@ -1,0 +1,25 @@
+task: xsum_inst
+dataset_path: EdinburghNLP/xsum
+dataset_name: null
+test_split: test
+training_split: train
+validation_split: validation
+output_type: generate_until
+fewshot_split: train
+process_docs: !function utils.process_xsum
+doc_to_text: 'Text: {{document}}
+
+  One-sentence summary:'
+doc_to_target: '{{summary}}'
+generation_kwargs:
+  until: []
+  max_gen_toks: 1024
+metric_list:
+  - metric: bleu
+    aggregation: bleu
+    higher_is_better: true
+  - metric: !function utils.rouge1
+    aggregation: !function utils.rouge1_agg
+    higher_is_better: true
+metadata:
+  version: 1.0


### PR DESCRIPTION
## Pull Request Checklist
- [x] The title of the PR is clear and concise.
- [x] I have provided a detailed description of the changes and the reason for the changes.
- [x] I have linked the related issue(s) in the description (if applicable).
- [x] I have followed the coding guidelines of this project.
- [x] I have ensured there are no breaking changes.
- [x] I have updated related documentation (if applicable).
- [x] I have added reviewers, including at least one member of the MLOps team (@hrosegalb, @PaulNdrei, @ankush13r, @igorktech)

## Description

We've had issues with the evaluations of the latest version of ALIA (`ALIA-40b-instruct-2601`) because the model is now better aligned, it uses Markdown in its outputs and is also quite verbose, providing larger outputs to simpler questions. This has caused problems with some evaluation tasks we have in Harness:
* `mgsm` task outputs were cut off earlier than the model could get to the actual answer, due to Harness's default `max_gen_toks` of 128
* summarization tasks were set to stop generation on `\n\n`, which the model now uses to split paragraphs
* `xquad` tasks were set to stop generation on `\n`, which the model would use in its output before providing the actual answer

We discussed this internally and decided to modify the tasks to better suit the scenarios in which we want to evaluate aligned models, by increasing the `max_gen_toks` and modifying stop criteria. However, in order to maintain reproducibility with the main Harness version and to avoid affecting the evaluation of base models, our solution for now was to create alternate implementations of the same tasks, suffixed by `_inst`, which can be used internally to evaluate the new models.

These new tasks are all under `iberobench_inst`, and the description of all the modifications can be found in `lm_eval/tasks/iberobench_inst/README.md`.

## Issue Link(s)
N/A

## Testing

I tested all of the new tasks individually and also all of the old tasks to make sure they still work as intended since they were not modified. The results are all in `/gpfs/projects/bsc88/mlops-lm-evaluation-harness/fix_line_break_criteria/results`.